### PR TITLE
Add support for Dawn of War and add more endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ OCaml SDK for the relic-link API provided by [World's Edge Studio](https://www.a
 ## Acknowledgements
 
 A big thank you to Christopher Zimmermann for his zlib related c stubs and to the librematch team for their helpful research and advice.
+
+## References
+
+* https://librematch.github.io/librematch-rlink_client/

--- a/lib/api/community/advertisement.ml
+++ b/lib/api/community/advertisement.ml
@@ -1,6 +1,6 @@
 open Lwt.Syntax
 
-let get ?(start = 1) ?(count = 100) game domain send =
+let get ?(start = 0) ?(count = 100) game domain send =
   let base_url = Uri.make ~scheme:"https" ~host:domain ~path:"/community/advertisement/findAdvertisements" () in
   let url =
     Uri.with_query'

--- a/lib/api/community/leaderboard.ml
+++ b/lib/api/community/leaderboard.ml
@@ -13,7 +13,7 @@ let get_available_leaderboards game domain send =
 
 let get game domain send = get_available_leaderboards game domain send
 
-let get_avatar ?(profile_ids = []) game domain send =
+let get_avatar ~profile_ids game domain send =
   match profile_ids with
   | [] -> Lwt.fail_with "Profile IDs list cannot be empty"
   | _ids ->

--- a/lib/api/community/leaderboard.ml
+++ b/lib/api/community/leaderboard.ml
@@ -1,6 +1,6 @@
 open Lwt.Syntax
 
-let get game domain send =
+let get_available_leaderboards game domain send =
   let base_url = Uri.make ~scheme:"https" ~host:domain ~path:"/community/leaderboard/GetAvailableLeaderboards" () in
   let url = Uri.with_query' base_url [ "title", Data.Game.to_str game; "format", "json" ] in
   let* json = send url in
@@ -10,6 +10,8 @@ let get game domain send =
     Lwt.return @@ Some model
   | None -> Lwt.return None
 ;;
+
+let get game domain send = get_available_leaderboards game domain send
 
 let get_avatar ?(profile_ids = []) game domain send =
   match profile_ids with

--- a/lib/api/community/leaderboard.ml
+++ b/lib/api/community/leaderboard.ml
@@ -2,7 +2,7 @@ open Lwt.Syntax
 
 let get game domain send =
   let base_url = Uri.make ~scheme:"https" ~host:domain ~path:"/community/leaderboard/GetAvailableLeaderboards" () in
-  let url = Uri.with_query' base_url [ "title", Data.Game.to_str game ] in
+  let url = Uri.with_query' base_url [ "title", Data.Game.to_str game; "format", "json" ] in
   let* json = send url in
   match json with
   | Some j ->
@@ -17,7 +17,9 @@ let get_avatar ?(profile_ids = []) game domain send =
   | _ids ->
     let base_url = Uri.make ~scheme:"https" ~host:domain ~path:"/community/leaderboard/GetAvatarStatForProfile" () in
     let url =
-      Uri.with_query' base_url [ "title", Data.Game.to_str game; "profile_ids", Data.Query.encode_lst_i profile_ids ]
+      Uri.with_query'
+        base_url
+        [ "title", Data.Game.to_str game; "profile_ids", Data.Query.encode_lst_i profile_ids; "format", "json" ]
     in
     let* json = send url in
     (match json with
@@ -47,6 +49,7 @@ let get_leaderboard_2
       ; "leaderboard_id", string_of_int leaderboard_id
       ; "start", string_of_int start
       ; "count", string_of_int count
+      ; "format", "json"
       ]
   in
   let* json = send url in

--- a/lib/api/community/leaderboard.ml
+++ b/lib/api/community/leaderboard.ml
@@ -59,3 +59,22 @@ let get_leaderboard_2
     Lwt.return @@ Some model
   | None -> Lwt.return None
 ;;
+
+let get_personal_stat ~profile_ids game domain send =
+  match profile_ids with
+  | [] -> Lwt.fail_with "Profile IDs list cannot be empty"
+  | _ ->
+    let base_url = Uri.make ~scheme:"https" ~host:domain ~path:"/community/leaderboard/getPersonalStat" () in
+    let profile_ids_j : Yojson.Basic.t = `List (List.map (fun i -> `Int i) profile_ids) in
+    let url =
+      Uri.with_query'
+        base_url
+        [ "title", Data.Game.to_str game; "format", "json"; "profile_ids", Yojson.Basic.to_string profile_ids_j ]
+    in
+    let* json = send url in
+    (match json with
+     | Some j ->
+       let model = Models.Response.Community.Personal_stat.from_json j in
+       Lwt.return @@ Some model
+     | None -> Lwt.return None)
+;;

--- a/lib/api/community/leaderboard.ml
+++ b/lib/api/community/leaderboard.ml
@@ -30,14 +30,14 @@ let get_avatar ?(profile_ids = []) game domain send =
 ;;
 
 let get_leaderboard_2
-  ?(sortby = Models.Stub.Community.Leaderboard_sorting.ByRating)
-  ?(platform = "PC_STEAM")
-  ?(leaderboard_id = 3)
-  ?(start = 1)
-  ?(count = 100)
-  game
-  domain
-  send
+      ?(sortby = Models.Stub.Community.Leaderboard_sorting.ByRating)
+      ?(platform = "PC_STEAM")
+      ?(leaderboard_id = 3)
+      ?(start = 1)
+      ?(count = 100)
+      game
+      domain
+      send
   =
   let base_url = Uri.make ~scheme:"https" ~host:domain ~path:"/community/leaderboard/getLeaderboard2" () in
   let url =

--- a/lib/api/community/leaderboard.ml
+++ b/lib/api/community/leaderboard.ml
@@ -60,6 +60,25 @@ let get_leaderboard_2
   | None -> Lwt.return None
 ;;
 
+let get_recent_match_history ~profile_ids game domain send =
+  match profile_ids with
+  | [] -> Lwt.fail_with "Profile IDs list cannot be empty"
+  | _ ->
+    let base_url = Uri.make ~scheme:"https" ~host:domain ~path:"/community/leaderboard/getRecentMatchHistory" () in
+    let profile_ids_j : Yojson.Basic.t = `List (List.map (fun i -> `Int i) profile_ids) in
+    let url =
+      Uri.with_query'
+        base_url
+        [ "title", Data.Game.to_str game; "format", "json"; "profile_ids", Yojson.Basic.to_string profile_ids_j ]
+    in
+    let* json = send url in
+    (match json with
+     | Some j ->
+       let model = Models.Response.Community.Recent_match_history.from_json j in
+       Lwt.return @@ Some model
+     | None -> Lwt.return None)
+;;
+
 let get_personal_stat ~profile_ids game domain send =
   match profile_ids with
   | [] -> Lwt.fail_with "Profile IDs list cannot be empty"

--- a/lib/api/community/leaderboard.ml
+++ b/lib/api/community/leaderboard.ml
@@ -36,7 +36,7 @@ let get_leaderboard_2
       ?(platform = "PC_STEAM")
       ?(leaderboard_id = 3)
       ?(start = 1)
-      ?(count = 100)
+      ?(count = 200)
       game
       domain
       send

--- a/lib/api/community/leaderboard.mli
+++ b/lib/api/community/leaderboard.mli
@@ -1,0 +1,44 @@
+val get_available_leaderboards
+  :  Data.Game.t
+  -> string
+  -> (Uri.t -> Yojson.Basic.t option Lwt.t)
+  -> Models.Response.Community.Leaderboard.t option Lwt.t
+
+val get
+  :  Data.Game.t
+  -> string
+  -> (Uri.t -> Yojson.Basic.t option Lwt.t)
+  -> Models.Response.Community.Leaderboard.t option Lwt.t
+[@@deprecated "Use the more clearly named 'get_available_leaderboards' instead"]
+
+val get_avatar
+  :  ?profile_ids:int list
+  -> Data.Game.t
+  -> string
+  -> (Uri.t -> Yojson.Basic.t option Lwt.t)
+  -> Models.Response.Community.Avatar_stat.t option Lwt.t
+
+val get_leaderboard_2
+  :  ?sortby:Models.Stub.Community.Leaderboard_sorting.t
+  -> ?platform:string
+  -> ?leaderboard_id:int
+  -> ?start:int
+  -> ?count:int
+  -> Data.Game.t
+  -> string
+  -> (Uri.t -> Yojson.Basic.t option Lwt.t)
+  -> Models.Response.Community.Leaderboard2.t option Lwt.t
+
+val get_recent_match_history
+  :  profile_ids:int list
+  -> Data.Game.t
+  -> string
+  -> (Uri.t -> Yojson.Basic.t option Lwt.t)
+  -> Models.Response.Community.Recent_match_history.t option Lwt.t
+
+val get_personal_stat
+  :  profile_ids:int list
+  -> Data.Game.t
+  -> string
+  -> (Uri.t -> Yojson.Basic.t option Lwt.t)
+  -> Models.Response.Community.Personal_stat.t option Lwt.t

--- a/lib/data/game.ml
+++ b/lib/data/game.ml
@@ -3,6 +3,23 @@ type t =
   | Age2
   | Age3
   | Age4
+  | Coh3
+  | Dow1de
 
-let to_str = function Age1 -> "age1" | Age2 -> "age2" | Age3 -> "age3" | Age4 -> "age4"
-let to_app_id = function Age1 -> 1017900 | Age2 -> 813780 | Age3 -> 933110 | Age4 -> 1466860
+let to_str = function
+  | Age1 -> "age1"
+  | Age2 -> "age2"
+  | Age3 -> "age3"
+  | Age4 -> "age4"
+  | Coh3 -> "coh3"
+  | Dow1de -> "dow1-de"
+;;
+
+let to_app_id = function
+  | Age1 -> 1017900
+  | Age2 -> 813780
+  | Age3 -> 933110
+  | Age4 -> 1466860
+  | Coh3 -> 1677280
+  | Dow1de -> 3556750
+;;

--- a/lib/data/game.ml
+++ b/lib/data/game.ml
@@ -23,3 +23,9 @@ let to_app_id = function
   | Coh3 -> 1677280
   | Dow1de -> 3556750
 ;;
+
+let to_domain = function
+  | Age1 | Age2 | Age3 | Age4 -> "aoe-api.worldsedgelink.com"
+  | Coh3 -> "coh3-api.reliclink.com"
+  | Dow1de -> "dow-api.reliclink.com"
+;;

--- a/lib/data/game.mli
+++ b/lib/data/game.mli
@@ -10,6 +10,8 @@ type t =
   | Age2 (** Age of Empires 2: Definitive Edition *)
   | Age3 (** Age of Empires 3: Definitive Edition *)
   | Age4 (** Age of Empires 4 *)
+  | Coh3 (** Company of Heroes 3 *)
+  | Dow1de (** Dawn of War: Definitive Edition *)
 
 (** [to_str g] converts a game [g] into its string representation for use in the relic-link API *)
 val to_str : t -> string

--- a/lib/data/game.mli
+++ b/lib/data/game.mli
@@ -18,3 +18,6 @@ val to_str : t -> string
 
 (** [to_app_id g] converts a game [g] into its steam app id *)
 val to_app_id : t -> int
+
+(** [to_domain g] converts a game [g] into a string representation of the domain endpoint *)
+val to_domain : t -> string

--- a/lib/data/game.mli
+++ b/lib/data/game.mli
@@ -16,5 +16,5 @@ type t =
 (** [to_str g] converts a game [g] into its string representation for use in the relic-link API *)
 val to_str : t -> string
 
-(** [to_str g] converts a game [g] into its steam app id *)
+(** [to_app_id g] converts a game [g] into its steam app id *)
 val to_app_id : t -> int

--- a/lib/models/response/community/personal_stat.ml
+++ b/lib/models/response/community/personal_stat.ml
@@ -1,0 +1,22 @@
+type t =
+  { result : Stub.Community.Response.t
+  ; stat_groups : Stub.Community.Stat_group.t list
+  ; leaderboard_stats : Stub.Community.Leaderboard_stat.t list
+  }
+
+let to_json l =
+  `Assoc
+    [ "result", Stub.Community.Response.to_json l.result
+    ; "statGroups", `List (List.map Stub.Community.Stat_group.to_json l.stat_groups)
+    ; "leaderboardStats", `List (List.map Stub.Community.Leaderboard_stat.to_json l.leaderboard_stats)
+    ]
+;;
+
+let from_json json =
+  let open Yojson.Basic.Util in
+  { result = json |> member "result" |> Stub.Community.Response.from_json
+  ; stat_groups = json |> member "statGroups" |> to_list |> List.map Stub.Community.Stat_group.from_json
+  ; leaderboard_stats =
+      json |> member "leaderboardStats" |> to_list |> List.map Stub.Community.Leaderboard_stat.from_json
+  }
+;;

--- a/lib/models/response/community/recent_match_history.ml
+++ b/lib/models/response/community/recent_match_history.ml
@@ -1,0 +1,23 @@
+type t =
+  { result : Stub.Community.Response.t
+  ; match_history_stats : Stub.Community.Match_history_stats.t list
+  ; profiles : Stub.Community.Avatar.t list
+  }
+
+let to_json r =
+  `Assoc
+    [ "result", Stub.Community.Response.to_json r.result
+    ; "matchHistoryStats", `List (List.map Stub.Community.Match_history_stats.to_json r.match_history_stats)
+    ; "profiles", `List (List.map Stub.Community.Avatar.to_json r.profiles)
+    ]
+;;
+
+let from_json json =
+  let open Yojson.Basic.Util in
+  { result = Yojson.Basic.Util.(json |> member "result" |> Stub.Community.Response.from_json)
+  ; match_history_stats =
+      Yojson.Basic.Util.(
+        json |> member "matchHistoryStats" |> to_list |> List.map Stub.Community.Match_history_stats.from_json)
+  ; profiles = json |> member "profiles" |> to_list |> List.map Stub.Community.Avatar.from_json
+  }
+;;

--- a/lib/models/stub/community/leaderboard_stat.ml
+++ b/lib/models/stub/community/leaderboard_stat.ml
@@ -9,13 +9,13 @@ type t =
   ; rank : int
   ; ranktotal : int
   ; ranklevel : int
-  ; rating : int
+  ; rating : int option
   ; regionrank : int
   ; regionranktotal : int
   ; lastmatchdate : int
   ; highestrank : int
   ; highestranklevel : int
-  ; highestrating : int
+  ; highestrating : int option
   }
 
 let to_json sg =
@@ -30,13 +30,15 @@ let to_json sg =
     ; "rank", `Int sg.rank
     ; "ranktotal", `Int sg.ranktotal
     ; "ranklevel", `Int sg.ranklevel
-    ; "rating", `Int sg.rating
+    ; "rating", `Int (Option.value ~default:0 sg.rating)
+      (* TODO: maybe do something more sensible than default to 0? *)
     ; "regionrank", `Int sg.regionrank
     ; "regionranktotal", `Int sg.regionranktotal
     ; "lastmatchdate", `Int sg.lastmatchdate
     ; "highestrank", `Int sg.highestrank
     ; "highestranklevel", `Int sg.highestranklevel
-    ; "highestrating", `Int sg.highestrating
+    ; "highestrating", `Int (Option.value ~default:0 sg.highestrating)
+      (* TODO: maybe do something more sensible than default to 0? *)
     ]
 ;;
 
@@ -52,12 +54,12 @@ let from_json json =
   ; rank = json |> member "rank" |> to_int
   ; ranktotal = json |> member "ranktotal" |> to_int
   ; ranklevel = json |> member "ranklevel" |> to_int
-  ; rating = json |> member "rating" |> to_int
+  ; rating = json |> member "rating" |> to_int_option
   ; regionrank = json |> member "regionrank" |> to_int
   ; regionranktotal = json |> member "regionranktotal" |> to_int
   ; lastmatchdate = json |> member "lastmatchdate" |> to_int
   ; highestrank = json |> member "highestrank" |> to_int
   ; highestranklevel = json |> member "highestranklevel" |> to_int
-  ; highestrating = json |> member "highestrating" |> to_int
+  ; highestrating = json |> member "highestrating" |> to_int_option
   }
 ;;

--- a/lib/models/stub/community/match_history_report_results.ml
+++ b/lib/models/stub/community/match_history_report_results.ml
@@ -1,0 +1,33 @@
+type t =
+  { matchhistory_id : int
+  ; profile_id : int
+  ; resulttype : int
+  ; teamid : int
+  ; race_id : int
+  ; xpgained : int (* ; counters: {} (* Empty object, no idea what it is for *) *)
+  ; matchstartdate : int
+  }
+
+let to_json m =
+  `Assoc
+    [ "matchhistory_id", `Int m.matchhistory_id
+    ; "profile_id", `Int m.profile_id
+    ; "resulttype", `Int m.resulttype
+    ; "teamid", `Int m.teamid
+    ; "race_id", `Int m.race_id
+    ; "xpgained", `Int m.xpgained
+    ; "matchstartdate", `Int m.matchstartdate
+    ]
+;;
+
+let from_json json =
+  let open Yojson.Basic.Util in
+  { matchhistory_id = json |> member "matchhistory_id" |> to_int
+  ; profile_id = json |> member "profile_id" |> to_int
+  ; resulttype = json |> member "resulttype" |> to_int
+  ; teamid = json |> member "teamid" |> to_int
+  ; race_id = json |> member "race_id" |> to_int
+  ; xpgained = json |> member "xpgained" |> to_int
+  ; matchstartdate = json |> member "matchstartdate" |> to_int
+  }
+;;

--- a/lib/models/stub/community/match_history_stats.ml
+++ b/lib/models/stub/community/match_history_stats.ml
@@ -1,0 +1,47 @@
+type t =
+  { id : int
+  ; creator_profile_id : int
+  ; mapname : string
+  ; maxplayers : int
+  ; matchtype_id : int
+  ; options : string (* ; slotinfo: string (* base64 encoded field, no idea what it contains *) *)
+  ; description : string
+  ; startgametime : int
+  ; completiontime : int
+  ; observertotal : int
+  ; match_history_report_results : Match_history_report_results.t list
+  }
+
+let to_json m =
+  `Assoc
+    [ "id", `Int m.id
+    ; "creator_profile_id", `Int m.creator_profile_id
+    ; "mapname", `String m.mapname
+    ; "maxplayers", `Int m.maxplayers
+    ; "matchtype_id", `Int m.matchtype_id
+    ; "options", `String m.options
+    ; "description", `String m.description
+    ; "startgametime", `Int m.startgametime
+    ; "completiontime", `Int m.completiontime
+    ; "observertotal", `Int m.observertotal
+    ; ( "matchhistoryreportresults"
+      , `List (List.map Match_history_report_results.to_json m.match_history_report_results) )
+    ]
+;;
+
+let from_json json =
+  let open Yojson.Basic.Util in
+  { id = json |> member "id" |> to_int
+  ; creator_profile_id = json |> member "creator_profile_id" |> to_int
+  ; mapname = json |> member "mapname" |> to_string
+  ; maxplayers = json |> member "maxplayers" |> to_int
+  ; matchtype_id = json |> member "matchtype_id" |> to_int
+  ; options = json |> member "options" |> to_string
+  ; description = json |> member "description" |> to_string
+  ; startgametime = json |> member "startgametime" |> to_int
+  ; completiontime = json |> member "completiontime" |> to_int
+  ; observertotal = json |> member "observertotal" |> to_int
+  ; match_history_report_results =
+      json |> member "matchhistoryreportresults" |> to_list |> List.map Match_history_report_results.from_json
+  }
+;;


### PR DESCRIPTION
This PR is best reviewed commit-by-commit.

If accepted this PR adds the following:

* Support for Dawn of War - Definitive Edition & Company of Heroes 3
* `to_domain` function for ease of use
* Data models and API calls for `getPersonalStat`
* Data models and API calls for `getRecentMatchHistory`

 :warning: Note: I have only tested the two new calls against the `dow1-de` title. :warning: 